### PR TITLE
add nuts-go and nuts-go-core as connected repos

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -216,6 +216,8 @@ modules = [
     'nuts-consent-store',
     'nuts-network-local',
     'nuts-fhir-validation',
+    'nuts-go',
+    'nuts-go-core',
     'nuts-auth']
 
 def download_repo(repo, branch):


### PR DESCRIPTION
Both repos weren't added yet

Signed-off-by: Wout Slakhorst <wout.slakhorst@nedap.com>