### PR TITLE
Remove RFCs from technical docs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -11,7 +11,6 @@ Nuts documentation
 
     pages/architecture/index.rst
     pages/technical/index.rst
-    pages/rfc/index.rst
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
have moved to gitbook. The articles remain, only the index has been changed.